### PR TITLE
Set default value for MYSQL_USE_UNICODE argument

### DIFF
--- a/flaskext/mysql.py
+++ b/flaskext/mysql.py
@@ -21,6 +21,7 @@ class MySQL(object):
         self.app.config.setdefault('MYSQL_DATABASE_PASSWORD', None)
         self.app.config.setdefault('MYSQL_DATABASE_DB', None)
         self.app.config.setdefault('MYSQL_DATABASE_CHARSET', 'utf8')
+        self.app.config.setdefault('MYSQL_USE_UNICODE', True)
         self.app.teardown_request(self.teardown_request)
         self.app.before_request(self.before_request)
 


### PR DESCRIPTION
The _MYSQL_USE_UNICODE_ has no default value. If the _MYSQL_USE_UNICODE_ is not defined in the Flask application's config variables a **Key Error** is raised. Setting a default value for this parameter avoids the error. 
