### PR TITLE
ignore reclose db error by pymysql.err.Error

### DIFF
--- a/flaskext/mysql.py
+++ b/flaskext/mysql.py
@@ -55,7 +55,10 @@ class MySQL(object):
     def teardown_request(self, exception):
         ctx = _ctx_stack.top
         if hasattr(ctx, "mysql_db"):
-            ctx.mysql_db.close()
+            try:
+                ctx.mysql_db.close()
+            catch Exception as e:
+                pass
 
     def get_db(self):
         ctx = _ctx_stack.top


### PR DESCRIPTION
when it used on flask with socketio, will be trigger teardown_request event as muilt times by the client long-polling, there were some trace log:

Traceback (most recent call last):
  File "D:\Tools\Python363\lib\site-packages\eventlet\wsgi.py", line 539, in handle_one_response
    result = self.application(self.environ, start_response)
  File "D:\Tools\Python363\lib\site-packages\flask\app.py", line 1997, in __call__
    return self.wsgi_app(environ, start_response)
  File "D:\Tools\Python363\lib\site-packages\engineio\middleware.py", line 49, in __call__
    return self.wsgi_app(environ, start_response)
  File "D:\Tools\Python363\lib\site-packages\flask\app.py", line 1993, in wsgi_app
    ctx.auto_pop(error)
  File "D:\Tools\Python363\lib\site-packages\flask\ctx.py", line 387, in auto_pop
    self.pop(exc)
  File "D:\Tools\Python363\lib\site-packages\flask\ctx.py", line 353, in pop
    self.app.do_teardown_request(exc)
  File "D:\Tools\Python363\lib\site-packages\flask\app.py", line 1879, in do_teardown_request
    func(exc)
  File "D:\Tools\Python363\lib\site-packages\flaskext\mysql.py", line 59, in teardown_request
    ctx.mysql_db.close()
  File "D:\Tools\Python363\lib\site-packages\pymysql\connections.py", line 728, in close
    raise err.Error("Already closed")
pymysql.err.Error: Already closed